### PR TITLE
Fix rule set to allow queries on database emulator

### DIFF
--- a/database.rules.json
+++ b/database.rules.json
@@ -1,15 +1,15 @@
 {
   "rules": {
     "recipes": {
-      ".indexOn": ["recipeName"]
+      ".indexOn": ["recipeName", "userName", "cookTime", "prepTime", "likes"]
     },
     "favorites": {
       "$user_id": {
-      	".indexOn": [".value"],
-          ".write": "$user_id === auth.uid"
+        ".indexOn": [".value"],
+        ".write": "$user_id === auth.uid"
       }
     },
-    ".read": "now < 1680904800000",  // 2023-4-8
-    ".write": "now < 1680904800000",  // 2023-4-8
+    ".read": "now < 1686838524000",  // 2023-6-15
+    ".write": "now < 1686838524000",  // 2023-6-15
   }
 }


### PR DESCRIPTION
Firebase realtime database has by default rules to allow only some days of public access to the database, fix the ruleset for the emulator to allow access until 15-6-2023 for now. (Already moved to same date for the online database)