### PR TITLE
Profanity filter 

### DIFF
--- a/app/src/main/java/com/github/siela1915/bootcamp/Tools/LanguageFilter.java
+++ b/app/src/main/java/com/github/siela1915/bootcamp/Tools/LanguageFilter.java
@@ -1,0 +1,458 @@
+package com.github.siela1915.bootcamp.Tools;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class LanguageFilter {
+
+    /*
+        Hardcoding the list of bad words means we don't have to load it from a remote or local
+        file when the app loads.
+        Storing the words as a HashSet instead of a simple List means we can search for a word in
+        O(1) instead of O(n), n being the size of the list.
+     */
+    private final static Set<String> badWords = new HashSet<>(Arrays.asList("2g1c",
+            "2 girls 1 cup",
+            "acrotomophilia",
+            "alabama hot pocket",
+            "alaskan pipeline",
+            "anal",
+            "anilingus",
+            "anus",
+            "apeshit",
+            "arsehole",
+            "ass",
+            "asshole",
+            "assmunch",
+            "auto erotic",
+            "autoerotic",
+            "babeland",
+            "baby batter",
+            "baby juice",
+            "ball gag",
+            "ball gravy",
+            "ball kicking",
+            "ball licking",
+            "ball sack",
+            "ball sucking",
+            "bangbros",
+            "bareback",
+            "barely legal",
+            "barenaked",
+            "bastard",
+            "bastardo",
+            "bastinado",
+            "beaner",
+            "beaners",
+            "beaver cleaver",
+            "beaver lips",
+            "bestiality",
+            "big black",
+            "big breasts",
+            "big knockers",
+            "big tits",
+            "bimbos",
+            "birdlock",
+            "bitches",
+            "bitch",
+            "black cock",
+            "blonde action",
+            "blonde on blonde action",
+            "blowjob",
+            "blow job",
+            "blow your load",
+            "blue waffle",
+            "blumpkin",
+            "bollocks",
+            "bondage",
+            "boner",
+            "boob",
+            "boobs",
+            "booty call",
+            "brown showers",
+            "brunette action",
+            "bukkake",
+            "bulldyke",
+            "bullet vibe",
+            "bullshit",
+            "bung hole",
+            "bunghole",
+            "busty",
+            "buttcheeks",
+            "butthole",
+            "camel toe",
+            "camgirl",
+            "camslut",
+            "camwhore",
+            "carpet muncher",
+            "carpetmuncher",
+            "chocolate rosebuds",
+            "circlejerk",
+            "cleveland steamer",
+            "clitoris",
+            "clover clamps",
+            "clusterfuck",
+            "cock",
+            "cocks",
+            "coprolagnia",
+            "coprophilia",
+            "cornhole",
+            "coon",
+            "coons",
+            "creampie",
+            "cumming",
+            "cunnilingus",
+            "cunt",
+            "darkie",
+            "date rape",
+            "daterape",
+            "deep throat",
+            "deepthroat",
+            "dendrophilia",
+            "dildo",
+            "dingleberry",
+            "dingleberries",
+            "dirty pillows",
+            "dirty sanchez",
+            "doggie style",
+            "doggiestyle",
+            "doggy style",
+            "doggystyle",
+            "dog style",
+            "dolcett",
+            "domination",
+            "dominatrix",
+            "dommes",
+            "donkey punch",
+            "double dong",
+            "double penetration",
+            "dp action",
+            "dry hump",
+            "eat my ass",
+            "ecchi",
+            "ejaculation",
+            "erotic",
+            "erotism",
+            "escort",
+            "eunuch",
+            "faggot",
+            "fecal",
+            "fellatio",
+            "feltch",
+            "female squirting",
+            "femdom",
+            "figging",
+            "fingerbang",
+            "fingering",
+            "fisting",
+            "foot fetish",
+            "footjob",
+            "frotting",
+            "fuck",
+            "fuck buttons",
+            "fuckin",
+            "fucking",
+            "fucktards",
+            "fudge packer",
+            "fudgepacker",
+            "futanari",
+            "gang bang",
+            "gay sex",
+            "genitals",
+            "giant cock",
+            "girl on top",
+            "girls gone wild",
+            "goatcx",
+            "goatse",
+            "god damn",
+            "gokkun",
+            "golden shower",
+            "goodpoop",
+            "goo girl",
+            "goregasm",
+            "grope",
+            "group sex",
+            "g-spot",
+            "hand job",
+            "handjob",
+            "hard core",
+            "hardcore",
+            "hentai",
+            "homoerotic",
+            "honkey",
+            "hooker",
+            "hot carl",
+            "hot chick",
+            "how to kill",
+            "how to murder",
+            "huge fat",
+            "humping",
+            "incest",
+            "intercourse",
+            "jack off",
+            "jail bait",
+            "jailbait",
+            "jelly donut",
+            "jerk off",
+            "jigaboo",
+            "jiggaboo",
+            "jiggerboo",
+            "jizz",
+            "juggs",
+            "kike",
+            "kinbaku",
+            "kinkster",
+            "kinky",
+            "knobbing",
+            "leather restraint",
+            "leather straight jacket",
+            "lemon party",
+            "lolita",
+            "lovemaking",
+            "make me come",
+            "male squirting",
+            "masturbate",
+            "menage a trois",
+            "milf",
+            "missionary position",
+            "motherfucker",
+            "motherfucking",
+            "mound of venus",
+            "mr hands",
+            "muff diver",
+            "muffdiving",
+            "nambla",
+            "nawashi",
+            "negro",
+            "neonazi",
+            "nigga",
+            "nigger",
+            "nig nog",
+            "nimphomania",
+            "nipple",
+            "nipples",
+            "nsfw images",
+            "nude",
+            "nudity",
+            "nympho",
+            "nymphomania",
+            "octopussy",
+            "omorashi",
+            "one cup two girls",
+            "one guy one jar",
+            "orgasm",
+            "orgy",
+            "paedophile",
+            "panties",
+            "panty",
+            "pedobear",
+            "pedophile",
+            "pegging",
+            "penis",
+            "phone sex",
+            "piece of shit",
+            "pissing",
+            "piss pig",
+            "pisspig",
+            "playboy",
+            "pleasure chest",
+            "pole smoker",
+            "ponyplay",
+            "poontang",
+            "punany",
+            "poop chute",
+            "poopchute",
+            "porn",
+            "porno",
+            "pornography",
+            "prince albert piercing",
+            "pubes",
+            "pussy",
+            "queaf",
+            "queef",
+            "quim",
+            "raghead",
+            "raging boner",
+            "raping",
+            "rapist",
+            "rectum",
+            "reverse cowgirl",
+            "rimjob",
+            "rimming",
+            "rosy palm",
+            "rosy palm and her 5 sisters",
+            "rusty trombone",
+            "sadism",
+            "santorum",
+            "schlong",
+            "scissoring",
+            "semen",
+            "shaved beaver",
+            "shaved pussy",
+            "shemale",
+            "shibari",
+            "shit",
+            "shitblimp",
+            "shitty",
+            "shota",
+            "shrimping",
+            "skeet",
+            "slanteye",
+            "slut",
+            "s&m",
+            "smut",
+            "snatch",
+            "snowballing",
+            "sodomize",
+            "sodomy",
+            "son of a bitch",
+            "splooge",
+            "splooge moose",
+            "spooge",
+            "spread legs",
+            "spunk",
+            "strap on",
+            "strapon",
+            "strappado",
+            "strip club",
+            "style doggy",
+            "suck",
+            "sucks",
+            "suicide girls",
+            "sultry women",
+            "swastika",
+            "swinger",
+            "tainted love",
+            "taste my",
+            "tea bagging",
+            "threesome",
+            "throating",
+            "tied up",
+            "tight white",
+            "tits",
+            "titties",
+            "titty",
+            "tongue in a",
+            "topless",
+            "tosser",
+            "towelhead",
+            "tranny",
+            "tribadism",
+            "tub girl",
+            "tubgirl",
+            "tushy",
+            "twat",
+            "twink",
+            "twinkie",
+            "two girls one cup",
+            "undressing",
+            "upskirt",
+            "urethra play",
+            "urophilia",
+            "vagina",
+            "venus mound",
+            "vibrator",
+            "violet wand",
+            "vorarephilia",
+            "voyeur",
+            "vulva",
+            "wank",
+            "wetback",
+            "wet dream",
+            "white power",
+            "wrapping men",
+            "wrinkled starfish",
+            "yaoi",
+            "yellow showers",
+            "yiffy",
+            "zoophilia")
+    );
+    private final static int maxBadWordLength = 27;
+
+    /**
+     * Filters out rude words from a string. Replaces any rude words with stars ****
+     * @param input the string to filter.
+     * @return the filtered string.
+     * For a more extensive filter, see filterLangugage().
+     */
+    public static String filterSingleWords(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+        //Don't forget to filter out any punctuation or other symbols
+        String s = filterLeetSpeach(input).toLowerCase().replaceAll("[^a-z]", " ");
+        Set<String> words = new HashSet<>(Arrays.asList(
+                s.split(" ")
+        ));
+        for (String word : words) {
+            if (badWords.contains(word)) {
+                String stars = stars(word.length());
+                // Add (?i) to remove case sensitivity.
+                for (String option : leetOptions(word)) {
+                    input = input.replaceAll("(?i)" + option, stars);
+                }
+            }
+        }
+        return input;
+    }
+
+    /**
+     * Filters out rude words and combinations of words that are considered rude and replaces
+     * the whole combination with stars ****
+     * @param input the string to filter.
+     * @return the filtered string.
+     * For simple rude word filtering see filterSingleWords().
+     */
+    public static String filterLanguage(String input) {
+        if (input == null || input.isEmpty()) {
+            return input;
+        }
+        String output = filterLeetSpeach(input).toLowerCase().replaceAll("[^a-z]", " ");
+        for(int i = 0; i < output.length(); ++i) {
+            // from each letter, keep going to find bad words until either the end of the sentence
+            // is reached, or the max word length is reached.
+            for (int j = 1; j < (output.length() + 1 - i) && j < maxBadWordLength; ++j) {
+                String substring = output.substring(i, i + j);
+                if (badWords.contains(substring)) {
+                    output = output.replaceAll(substring, stars(substring.length()));
+                }
+            }
+        }
+        return output;
+    }
+
+    private static String stars(int length) {
+        char[] charsStars = new char[length];
+        Arrays.fill(charsStars, '*');
+        return new String(charsStars);
+    }
+
+    private final static String[] leetSymbols = new String[]{"1", "!", "3", "4", "@", "5", "7", "0", "9"};
+    private final static String[] leetReplacements = new String[]{"i", "i", "e", "a", "a", "s", "t", "o", "g"};
+
+    private static String filterLeetSpeach(String input) {
+        for (int i = 0; i < leetSymbols.length; ++i) {
+            input = input.replaceAll(leetSymbols[i], leetReplacements[i]);
+        }
+        return input;
+    }
+
+    private static List<String> leetOptions(String s) {
+        List<String> options = new ArrayList<>();
+        options.add(s);
+        for (int i = 0; i < leetSymbols.length; ++i) {
+            if (s.contains(leetReplacements[i])) {
+                options.add(s.replaceAll(leetReplacements[i], leetSymbols[i]));
+            }
+        }
+        return options;
+    }
+
+
+
+}

--- a/app/src/main/java/com/github/siela1915/bootcamp/Tools/LanguageFilter.java
+++ b/app/src/main/java/com/github/siela1915/bootcamp/Tools/LanguageFilter.java
@@ -1,9 +1,12 @@
 package com.github.siela1915.bootcamp.Tools;
 
+import com.github.siela1915.bootcamp.Recipes.Comment;
+
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -322,6 +325,7 @@ public class LanguageFilter {
             "strip club",
             "style doggy",
             "suck",
+            "suck my balls",
             "sucks",
             "suicide girls",
             "sultry women",
@@ -412,18 +416,69 @@ public class LanguageFilter {
         if (input == null || input.isEmpty()) {
             return input;
         }
-        String output = filterLeetSpeach(input).toLowerCase().replaceAll("[^a-z]", " ");
-        for(int i = 0; i < output.length(); ++i) {
+        String s = filterLeetSpeach(input).toLowerCase().replaceAll("[^a-z]", " ");
+        for(int i = 0; i < s.length(); ++i) {
             // from each letter, keep going to find bad words until either the end of the sentence
             // is reached, or the max word length is reached.
-            for (int j = 1; j < (output.length() + 1 - i) && j < maxBadWordLength; ++j) {
-                String substring = output.substring(i, i + j);
+            for (int j = 1; j < (s.length() + 1 - i) && j < maxBadWordLength; ++j) {
+                String substring = s.substring(i, i + j);
                 if (badWords.contains(substring)) {
-                    output = output.replaceAll(substring, stars(substring.length()));
+                    for (String option : leetOptions(substring)) {
+                        input = input.replaceAll("(?i)" + option, stars(option.length()));
+                    }
                 }
             }
         }
-        return output;
+        return input;
+    }
+
+    /**
+     * Applies a profanity filter on the given comment and its replies.
+     * @param comment the comment to filter.
+     * @param filterLanguage filters certain expressions and phrases in addition to words when true,
+     *                       only filters words when false.
+     * @return the filtered comment and filtered replies.
+     */
+    public static Comment filterComment(Comment comment, boolean filterLanguage) {
+        if (filterLanguage) {
+            String filtered = filterLanguage(comment.getContent());
+            if (comment.getReplies().size() == 0) {
+                return new Comment(comment.getLikes(), filtered, new LinkedList<>());
+            }
+            LinkedList<Comment> replies = new LinkedList<>();
+            for (Comment c : comment.getReplies()) {
+                replies.add(filterComment(c, true));
+            }
+            return new Comment(comment.getLikes(), filtered, replies);
+        } else {
+            String filtered = filterSingleWords(comment.getContent());
+            if (comment.getReplies().size() == 0) {
+                return new Comment(comment.getLikes(), filtered, new LinkedList<>());
+            }
+            LinkedList<Comment> replies = new LinkedList<>();
+            for (Comment c : comment.getReplies()) {
+                replies.add(filterComment(c, false));
+            }
+            return new Comment(comment.getLikes(), filtered, replies);
+        }
+    }
+
+    /**
+     * Applies a profanity filter on a list of comments and their replies.
+     * @param comments the list of comments to filter
+     * @param filterLanguage filters certain expressions and phrases in addition to words when true,
+     *                       only filters words when false.
+     * @return a list of the fitlered comments and their replies.
+     */
+    public static List<Comment> filterComments(List<Comment> comments, boolean filterLanguage) {
+        if (comments == null) {
+            throw new IllegalArgumentException("Cannot filter a null list.");
+        }
+        List<Comment> ls = new ArrayList<>();
+        for (Comment c : comments) {
+            ls.add(filterComment(c, filterLanguage));
+        }
+        return ls;
     }
 
     private static String stars(int length) {

--- a/app/src/test/java/com/github/siela1915/dishdelish/LanguageFilterTest.java
+++ b/app/src/test/java/com/github/siela1915/dishdelish/LanguageFilterTest.java
@@ -1,10 +1,17 @@
 package com.github.siela1915.dishdelish;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
+import com.github.siela1915.bootcamp.Recipes.Comment;
 import com.github.siela1915.bootcamp.Tools.LanguageFilter;
 
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.List;
 
 public class LanguageFilterTest {
 
@@ -18,7 +25,7 @@ public class LanguageFilterTest {
     @Test
     public void filterLanguageFiltersOutMultipleWordCurse() {
         String badString = "That motherfucking son of a bitch!";
-        String goodString = "That ************* *** ** * *****";
+        String goodString = "That ************* **************!";
         assertEquals(goodString, LanguageFilter.filterLanguage(badString));
     }
 
@@ -27,6 +34,59 @@ public class LanguageFilterTest {
         String badString = "Sh!t that m0therfucker will 3@t my @ss";
         String goodString = "**** that ************ will 3@t my ***";
         assertEquals(goodString, LanguageFilter.filterSingleWords(badString));
+    }
+
+    @Test
+    public void filterCommentWithWordsOnlyFiltersRepliesToo() {
+        Comment comment = new Comment(100,
+                "Fuck this son of a bitch and his home-cooking.",
+                new LinkedList<>(Arrays.asList(
+                        new Comment(13, "What a cunt!"),
+                        new Comment(22, "nah he's got a point, the cooking sucks"))
+                ));
+        Comment filtered = new Comment(100,
+                "**** this son of a ***** and his home-cooking.",
+                new LinkedList<>(Arrays.asList(
+                        new Comment(13, "What a ****!"),
+                        new Comment(22, "nah he's got a point, the cooking *****"))
+                ));
+        assertEquals(filtered, LanguageFilter.filterComment(comment, false));
+    }
+
+    @Test
+    public void filterCommentWithLanguageEnabledFiltersRepliesToo() {
+        Comment comment = new Comment(100,
+                "Fuck this son of a bitch and his home-cooking.",
+                new LinkedList<>(Arrays.asList(
+                        new Comment(13, "Suck my balls"),
+                        new Comment(22, "nah he's got a point, the cooking sucks"))
+                ));
+        Comment filtered = new Comment(100,
+                "**** this ************** and his home-cooking.",
+                new LinkedList<>(Arrays.asList(
+                        new Comment(13, "*************"),
+                        new Comment(22, "nah he's got a point, the cooking *****"))
+                ));
+        assertEquals(filtered, LanguageFilter.filterComment(comment, true));
+    }
+
+    @Test
+    public void filterListOfCommentsFiltersAllComments() {
+        List<Comment> ls = Arrays.asList(
+                new Comment(12, "Rude fucking shit"),
+                new Comment(112938477, "I love titties!"),
+                new Comment(1, "suck mine then"));
+        List<Comment> clean = Arrays.asList(
+                new Comment(12, "Rude ******* ****"),
+                new Comment(112938477, "I love *******!"),
+                new Comment(1, "**** mine then"));
+        assertEquals(clean, LanguageFilter.filterComments(ls, false));
+    }
+
+    @Test
+    public void filterListOfCommentsThrowsExceptionWhenArgumentIsNull() {
+        assertThrows(IllegalArgumentException.class,
+                () -> LanguageFilter.filterComments(null, true));
     }
 
 }

--- a/app/src/test/java/com/github/siela1915/dishdelish/LanguageFilterTest.java
+++ b/app/src/test/java/com/github/siela1915/dishdelish/LanguageFilterTest.java
@@ -1,0 +1,32 @@
+package com.github.siela1915.dishdelish;
+
+import static org.junit.Assert.assertEquals;
+
+import com.github.siela1915.bootcamp.Tools.LanguageFilter;
+
+import org.junit.Test;
+
+public class LanguageFilterTest {
+
+    @Test
+    public void filterSingleWordsFiltersOutSingleWordCurse() {
+        String badString = "This fucking comment talks about anal and shit.";
+        String goodString = "This ******* comment talks about **** and ****.";
+        assertEquals(goodString, LanguageFilter.filterSingleWords(badString));
+    }
+
+    @Test
+    public void filterLanguageFiltersOutMultipleWordCurse() {
+        String badString = "That motherfucking son of a bitch!";
+        String goodString = "That ************* *** ** * *****";
+        assertEquals(goodString, LanguageFilter.filterLanguage(badString));
+    }
+
+    @Test
+    public void filterSingleWordsFiltersOutLeetSpeak() {
+        String badString = "Sh!t that m0therfucker will 3@t my @ss";
+        String goodString = "**** that ************ will 3@t my ***";
+        assertEquals(goodString, LanguageFilter.filterSingleWords(badString));
+    }
+
+}

--- a/app/src/test/java/com/github/siela1915/dishdelish/LanguageFilterTest.java
+++ b/app/src/test/java/com/github/siela1915/dishdelish/LanguageFilterTest.java
@@ -8,7 +8,6 @@ import com.github.siela1915.bootcamp.Tools.LanguageFilter;
 
 import org.junit.Test;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.LinkedList;
 import java.util.List;
@@ -16,7 +15,68 @@ import java.util.List;
 public class LanguageFilterTest {
 
     @Test
-    public void filterSingleWordsFiltersOutSingleWordCurse() {
+    public void filterSingleWordsCensorsBadWord() {
+        String bad = "titties";
+        assertEquals("*******", LanguageFilter.filterSingleWords(bad));
+    }
+
+    @Test
+    public void filterSingleWordsCensorsCapitalLetters() {
+        String bad = "Fuck";
+        assertEquals("****", LanguageFilter.filterSingleWords(bad));
+    }
+
+    @Test
+    public void filterSingleWordsKeepsPunctuation() {
+        String bad = "shit.";
+        assertEquals("****.", LanguageFilter.filterSingleWords(bad));
+    }
+
+    @Test
+    public void filterSingleWordsCensorsLeetSpeech() {
+        String bad = "@ss";
+        assertEquals("***", LanguageFilter.filterSingleWords(bad));
+    }
+
+    @Test
+    public void filterSingleWordsKeepsNormalNumbers() {
+        String falseBad = "Fuck your 145 kids.";
+        assertEquals("**** your 145 kids.", LanguageFilter.filterSingleWords(falseBad));
+    }
+
+    @Test
+    public void filterLanguageCensorsBadWord() {
+        String bad = "titties";
+        assertEquals("*******", LanguageFilter.filterLanguage(bad));
+    }
+
+    @Test
+    public void filterLanguageCensorsCapitalLetters() {
+        String bad = "Fuck";
+        assertEquals("****", LanguageFilter.filterLanguage(bad));
+    }
+
+    @Test
+    public void filterLanguageKeepsPunctuation() {
+        String bad = "shit.";
+        assertEquals("****.", LanguageFilter.filterLanguage(bad));
+    }
+
+    @Test
+    public void filterLanguageCensorsLeetSpeech() {
+        String bad = "@ss";
+        assertEquals("***", LanguageFilter.filterLanguage(bad));
+    }
+
+    @Test
+    public void filterLanguageKeepsNormalNumbers() {
+        String falseBad = "Fuck your 145 kids.";
+        assertEquals("**** your 145 kids.", LanguageFilter.filterLanguage(falseBad));
+    }
+
+
+    @Test
+    public void filterSingleWordsFiltersOutMultipleWords() {
         String badString = "This fucking comment talks about anal and shit.";
         String goodString = "This ******* comment talks about **** and ****.";
         assertEquals(goodString, LanguageFilter.filterSingleWords(badString));
@@ -41,13 +101,13 @@ public class LanguageFilterTest {
         Comment comment = new Comment(100,
                 "Fuck this son of a bitch and his home-cooking.",
                 new LinkedList<>(Arrays.asList(
-                        new Comment(13, "What a cunt!"),
+                        new Comment(13, "What a cunt"),
                         new Comment(22, "nah he's got a point, the cooking sucks"))
                 ));
         Comment filtered = new Comment(100,
                 "**** this son of a ***** and his home-cooking.",
                 new LinkedList<>(Arrays.asList(
-                        new Comment(13, "What a ****!"),
+                        new Comment(13, "What a ****"),
                         new Comment(22, "nah he's got a point, the cooking *****"))
                 ));
         assertEquals(filtered, LanguageFilter.filterComment(comment, false));
@@ -64,8 +124,8 @@ public class LanguageFilterTest {
         Comment filtered = new Comment(100,
                 "**** this ************** and his home-cooking.",
                 new LinkedList<>(Arrays.asList(
-                        new Comment(13, "*************"),
-                        new Comment(22, "nah he's got a point, the cooking *****"))
+                        new Comment(13, "**** my balls"),
+                        new Comment(22, "nah he's got a point, the cooking ****s"))
                 ));
         assertEquals(filtered, LanguageFilter.filterComment(comment, true));
     }
@@ -74,11 +134,11 @@ public class LanguageFilterTest {
     public void filterListOfCommentsFiltersAllComments() {
         List<Comment> ls = Arrays.asList(
                 new Comment(12, "Rude fucking shit"),
-                new Comment(112938477, "I love titties!"),
+                new Comment(112938477, "I love titties"),
                 new Comment(1, "suck mine then"));
         List<Comment> clean = Arrays.asList(
                 new Comment(12, "Rude ******* ****"),
-                new Comment(112938477, "I love *******!"),
+                new Comment(112938477, "I love *******"),
                 new Comment(1, "**** mine then"));
         assertEquals(clean, LanguageFilter.filterComments(ls, false));
     }


### PR DESCRIPTION
This profanity filter censors bad words and expressions in strings and comments.
Leet speech is also censored. 
Note this filter is not perfect; indeed, one notable issue relies on adding ! at the end of a bad word, circumventing the censorship. This is due to the fact that ! is a symbol used for leet speech. This issue cannot be fixed unless the algorithm is modified to add more checks, significantly increasing complexity. Therefore I chose to keep the bug.