### PR TITLE
Override hashCode for recipes.

### DIFF
--- a/app/src/androidTest/java/com/github/siela1915/bootcamp/MainHomeActivityTest.java
+++ b/app/src/androidTest/java/com/github/siela1915/bootcamp/MainHomeActivityTest.java
@@ -390,9 +390,8 @@ public class MainHomeActivityTest {
         scenario= ActivityScenario.launch(MainHomeActivity.class);
         onView(withId(R.id.moreFilterTextView)).perform(click());
         onView(withId(R.id.btnFridge)).perform(click());
-        scenario.close();
-
         FirebaseAuthActivityTest.logoutSync();
+        scenario.close();
     }
 
     @Test

--- a/app/src/main/java/com/github/siela1915/bootcamp/Recipes/Recipe.java
+++ b/app/src/main/java/com/github/siela1915/bootcamp/Recipes/Recipe.java
@@ -333,6 +333,11 @@ public class Recipe implements Parcelable {
         return recipeName;
     }
 
+    @Override
+    public int hashCode() {
+        return uniqueKey.hashCode();
+    }
+
 }
 
 


### PR DESCRIPTION
Bug fix: hashCode for same recipe coming from different firebase queries use to evaluate to different numbers, thus resulting in duplicates in the HashSet instance.
Therefore overriding hashCode to use the hashCode of the uniqueKey attribute will ensure no two recipes with the same uniqueKey will be both added to a HashSet. 